### PR TITLE
fix: correct javascript errors export path

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"./javascript/es6": "./javascript/es6.js",
 		"./javascript/node": "./javascript/node.js",
 		"./javascript/style": "./javascript/style.js",
-		"./javascript/errors": "./rules/errors.js",
+		"./javascript/errors": "./javascript/errors.js",
 		"./javascript/strict": "./javascript/strict.js",
 		"./javascript/variables": "./javascript/variables.js",
 		"./package.json": "./package.json"


### PR DESCRIPTION
## Summary
- correct the `./javascript/errors` package export to point at the file that is actually published: `./javascript/errors.js`
- fixes clean import/require of `eslint-config-bryanberger/javascript/errors`

## Validation
- `node --input-type=module -e "import('./javascript/errors.js').then(()=>console.log('local javascript/errors import ok'))"`
- `node -e "require('./javascript/errors.js'); console.log('local javascript/errors require ok')"`

Related bounty: charles-openclaw/charles-microbounties#633